### PR TITLE
fix: removed travis dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "semantic-release": "semantic-release pre && semantic-release post",
     "lint": "tslint --project tsconfig.json --format stylish",
     "run-script": "npm run lint && npm run build && npm run test",
-    "precommit": "./scripts/pre-commit.sh",
-    "prepush": "npm run test",
-    "commitmsg": "validate-commit-msg",
     "release": "standard-version && git push --follow-tags origin master"
   },
   "devDependencies": {
@@ -52,7 +49,11 @@
       "js"
     ]
   },
-  "dependencies": {
-    "travis": "^0.1.1"
+  "husky": {
+    "hooks": {
+      "commit-msg": "validate-commit-msg",
+      "pre-commit": "./scripts/pre-commit.sh",
+      "pre-push": "npm run test"
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4359,10 +4359,6 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-travis@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/travis/-/travis-0.1.1.tgz#80fe1c36f6f3b739fce07e6063838ce436357d60"
-
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"


### PR DESCRIPTION
Looks like it was not used anywhere.
Also moved husky hooks from `scripts` section because of deprecation warning.